### PR TITLE
feat: 기본 게임 로직

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -41,6 +41,7 @@ MonoBehaviour:
   - Fire
   - RespawnSpaceship
   - ShowEndResult
+  - UpdateActionBar
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -386,8 +386,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerPrefab: {fileID: 7606058919849491897, guid: 232193f9d3c824aa2aaa1d1cf63017cb, type: 3}
-  gameDuration: 180
   timerText: {fileID: 1580891417}
+  actionBar: {fileID: 1617938852}
 --- !u!4 &929989994
 Transform:
   m_ObjectHideFlags: 0
@@ -599,6 +599,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1580891416}
+  - {fileID: 1617938851}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -640,7 +641,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -70}
+  m_AnchoredPosition: {x: 0, y: -75}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1580891417
@@ -665,8 +666,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00:00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 0e3ab6cb08e3a402d88fe805bb85d1c7, type: 2}
+  m_sharedMaterial: {fileID: 8869713884182402823, guid: 0e3ab6cb08e3a402d88fe805bb85d1c7, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -741,6 +742,142 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1580891415}
+  m_CullTransparentMesh: 1
+--- !u!1 &1617938850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1617938851}
+  - component: {fileID: 1617938853}
+  - component: {fileID: 1617938852}
+  m_Layer: 5
+  m_Name: ActionBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1617938851
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617938850}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1563058214}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 275}
+  m_SizeDelta: {x: 1000, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1617938852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617938850}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "ActionBar \uD14C\uC2A4\uD2B8 \uBA54\uC2DC\uC9C0"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 0e3ab6cb08e3a402d88fe805bb85d1c7, type: 2}
+  m_sharedMaterial: {fileID: 8869713884182402823, guid: 0e3ab6cb08e3a402d88fe805bb85d1c7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1617938853
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1617938850}
   m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Assets/Scripts/Game.meta
+++ b/Assets/Scripts/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d385ad507f6ef4906ac1ef70ab79a7a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/GameConstants.cs
+++ b/Assets/Scripts/Game/GameConstants.cs
@@ -1,0 +1,24 @@
+/// <summary>
+/// 게임 공용 상수
+/// </summary>
+public static class GameConstants
+{
+
+#region 대기 규칙
+
+    /// <summary>
+    /// 시작을 위해 기다리는 시간
+    /// </summary>
+    public const float WaitTimeBeforeGameStart = 10f;
+
+#endregion
+
+#region 게임 규칙
+
+    /// <summary>
+    /// 게임 시간
+    /// </summary>
+    public const float GameDuration = 180f;
+
+#endregion
+}

--- a/Assets/Scripts/Game/GameConstants.cs.meta
+++ b/Assets/Scripts/Game/GameConstants.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cf56948b1986c4bd28a2ef618a961f4b

--- a/Assets/Scripts/Game/GamePhase.cs
+++ b/Assets/Scripts/Game/GamePhase.cs
@@ -1,0 +1,31 @@
+using Photon.Realtime;
+
+public class GamePhase : Phase
+{
+    public GamePhase(GameManager session) : base(session) { }
+
+    public override void Initiailze()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public override void Terminate()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public override void OnJoin(Player newPlayer)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public override void OnLeft(Player otherPlayer)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public override void Tick()
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Assets/Scripts/Game/GamePhase.cs.meta
+++ b/Assets/Scripts/Game/GamePhase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3869d0e8dc5c3469e89e87935e957a78

--- a/Assets/Scripts/Game/Phase.cs
+++ b/Assets/Scripts/Game/Phase.cs
@@ -1,0 +1,56 @@
+using Photon.Pun;
+using Photon.Realtime;
+
+/// <summary>
+/// 게임 페이즈
+/// </summary>
+public abstract class Phase
+{
+
+    protected readonly GameManager session;
+
+    private float timeRemaining = 0f;
+    public virtual float TimeRemaining => timeRemaining;
+
+    protected Phase(GameManager session)
+    {
+        this.session = session;
+    }
+
+    /// <summary>
+    /// 페이즈 초기화를 시작할 때 호출됩니다.
+    /// </summary>
+    public abstract void Initiailze();
+
+    /// <summary>
+    /// 페이즈가 종료되어 정리할 때 호출됩니다.
+    /// </summary>
+    public abstract void Terminate();
+
+    /// <summary>
+    /// 플레이어가 세션에 입장하면 호출됩니다.
+    /// </summary>
+    /// <param name="newPlayer">입장 플레이어</param>
+    public abstract void OnJoin(Player newPlayer);
+
+    /// <summary>
+    /// 플레이어가 세션에서 퇴장하면 호출됩니다.
+    /// </summary>
+    /// <param name="oldPlayer">퇴장 플레이어</param>
+    public abstract void OnLeft(Player oldPlayer);
+
+    /// <summary>
+    /// 매 게임 시간(틱)마다 호출됩니다.
+    /// </summary>
+    public abstract void Tick();
+
+    /// <summary>
+    /// 게임 타이머를 업데이트합니다.
+    /// </summary>
+    /// <param name="time">게임 타이머</param>
+    protected virtual void UpdateTimer(float time)
+    {
+        this.timeRemaining = time;
+        this.session.photonView.RPC("UpdateTimer", RpcTarget.All, time);
+    }
+}

--- a/Assets/Scripts/Game/Phase.cs.meta
+++ b/Assets/Scripts/Game/Phase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b90147431571413cb85954067867a33

--- a/Assets/Scripts/Game/WaitPhase.cs
+++ b/Assets/Scripts/Game/WaitPhase.cs
@@ -1,0 +1,59 @@
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+/// <summary>
+/// 플레이어 대기 페이즈
+/// </summary>
+public class WaitPhase : Phase
+{
+
+    public WaitPhase(GameManager session) : base(session) { }
+
+    public override void Initiailze()
+    {
+        Debug.Log("[Phase - Wait] 초기화 요청");
+        this.UpdateTimer(GameConstants.WaitTimeBeforeGameStart);
+        this.session.photonView.RPC("UpdateActionBar", RpcTarget.All, "");
+    }
+
+    public override void Terminate()
+    {
+        Debug.Log("[Phase - Wait] 정리 요청");
+    }
+
+    public override void OnJoin(Player newPlayer)
+    {
+        Debug.Log($"[Phase - Wait] 플레이어 접속: {newPlayer.NickName}");
+    }
+
+    public override void OnLeft(Player otherPlayer)
+    {
+        Debug.Log($"[Phase - Wait] 플레이어 퇴장: {otherPlayer.NickName}");
+    }
+
+    public override void Tick()
+    {
+        // 현재 플레이어 수 확인 후, 홀수거나 2인 미만이면 대기
+        int playerCount = PhotonNetwork.PlayerList.Length;
+        if (playerCount < 2 || playerCount % 2 != 0)
+        {
+            // TODO State enum을 만들어 RPC로 이전하는 것이 좋을까?
+            this.session.photonView.RPC("UpdateActionBar", RpcTarget.All, "플레이어를 기다리는 중...");
+            return;
+        }
+
+        // 플레이어 수가 짝수이면 시작 카운트다운
+        if (this.TimeRemaining > 0f)
+        {
+            this.UpdateTimer(this.TimeRemaining - Time.fixedDeltaTime);
+            this.session.photonView.RPC("UpdateActionBar", RpcTarget.All, "추가 플레이어 대기 중...");
+        }
+        // 게임 시작
+        else
+        {
+            // TODO 게임 페이즈로 전환
+            Debug.Log($"[Phase - Wait] 게임 시작 준비");
+        }
+    }
+}

--- a/Assets/Scripts/Game/WaitPhase.cs.meta
+++ b/Assets/Scripts/Game/WaitPhase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed496dccb144e4bf6baa8fa26d403a5a

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,10 +1,19 @@
+using System.ComponentModel;
 using Photon.Pun;
 using Photon.Realtime;
 using TMPro;
 using UnityEngine;
 
+/// <summary>
+/// 게임 세션을 관리하는 스크립트
+/// </summary>
 public class GameManager : MonoBehaviourPunCallbacks
 {
+
+    /// <summary>
+    /// 게임 페이즈
+    /// </summary>
+    private Phase phase;
 
     /// <summary>
     /// 플레이어 프리팹
@@ -16,91 +25,97 @@ public class GameManager : MonoBehaviourPunCallbacks
     /// </summary>
     public TMP_Text timerText;
 
-    public float gameDuration = 180f; // 3분
-    private float timeRemaining;
-    private bool gameEnded = false;
+    /// <summary>
+    /// (UI) 액션바
+    /// </summary>
+    public TMP_Text actionBar;
 
     void Start()
     {
-        this.timeRemaining = this.gameDuration;
-
-        AssignRoles(); // TODO Remove
+        this.ChangePhase(new WaitPhase(this));
 
         // PhotonLauncher#OnJoinedRoom() 호출 이후
         // 씬이 전환되면서 마스터 클라이언트에서만 InRoom 플래그가
         // 활성화되므로 이후 난입하는 플레이어에겐 실행되지 않음 
         if (PhotonNetwork.InRoom)
-        {
             this.SpawnPlayer();
-        }
     }
 
     public override void OnJoinedRoom()
     {
         // 난입하는 플레이어에 대한 로직 실행
         if (!PhotonNetwork.IsMasterClient)
-        {
             this.SpawnPlayer();
-        }
     }
 
-    // 플레이어 스폰 처리
+    public override void OnPlayerEnteredRoom(Player newPlayer)
+    {
+        Debug.Log($"[GameManager] 플레이어 입장: {newPlayer.NickName}");
+        this.phase?.OnJoin(newPlayer);
+    }
+
+    public override void OnPlayerLeftRoom(Player otherPlayer)
+    {
+        Debug.Log($"[GameManager] 플레이어 퇴장: {otherPlayer.NickName}");
+        this.phase?.OnLeft(otherPlayer);
+    }
+
+    /// <summary>
+    /// 페이즈를 변경합니다.
+    /// </summary>
+    /// <param name="newPhase">새 페이즈</param>
+    /// <exception cref="System.Exception">동일한 페이즈인 경우 예외가 던져집니다</exception>
+    void ChangePhase(Phase newPhase)
+    {
+        // 마스터 클라이언트가 아닌 경우 무시
+        if (!PhotonNetwork.IsMasterClient)
+            return;
+
+        // 동일한 페이즈 변경 시도 검사
+        if (this.phase != null && this.phase.GetType() == newPhase.GetType())
+            throw new System.Exception("동일한 게임 페이즈로 변경할 수 없습니다.");
+
+        // 이전 페이즈 정리 후 새 페이즈 초기화
+        this.phase?.Terminate();
+        newPhase.Initiailze();
+        this.phase = newPhase;
+    }
+
+    /// <summary>
+    /// 플레이어 스폰을 처리합니다.
+    /// </summary>
     private void SpawnPlayer()
     {
         GameObject obj = PhotonNetwork.Instantiate(this.playerPrefab.name, Vector3.zero, Quaternion.identity);
         if (obj.GetComponent<PhotonView>().IsMine)
-        {
             Camera.main.GetComponent<CameraFollow>().target = obj.transform;
-        }
     }
 
-    void Update()
+    void FixedUpdate()
     {
-        if (PhotonNetwork.IsMasterClient && !gameEnded)
-        {
-            timeRemaining -= Time.deltaTime;
+        // 서버 사이드 로직
+        if (this.phase != null)
+            this.phase.Tick();
 
-            if (timeRemaining <= 0f)
-            {
-                timeRemaining = 0f;
-                EndGame("술래 승리! 시간 초과");
-            }
-
-            photonView.RPC("UpdateTimer", RpcTarget.All, timeRemaining);
-        }
+        // 클라이언트 사이드 로직
+        // TODO 액션바
     }
+
+#region RPC 처리
 
     [PunRPC]
     void UpdateTimer(float time)
     {
         int minutes = Mathf.FloorToInt(time / 60f);
         int seconds = Mathf.FloorToInt(time % 60f);
-        timerText.text = $"{minutes:D2}:{seconds:D2}";
-    }
-
-    void AssignRoles()
-    {
-        Player[] players = PhotonNetwork.PlayerList;
-
-        if (players.Length < 2)
-        {
-            Debug.LogWarning("플레이어가 부족합니다.");
-            return;
-        }
-
-        // TODO 흠...
-    }
-
-    void EndGame(string result)
-    {
-        this.gameEnded = true;
-        photonView.RPC("ShowEndResult", RpcTarget.All, result);
+        this.timerText.text = $"{minutes:D2}:{seconds:D2}";
     }
 
     [PunRPC]
-    void ShowEndResult(string message)
+    void UpdateActionBar(string message)
     {
-        Debug.Log("게임 종료: " + message);
-        // TODO 결과 창 UI 띄우기, 다시 시작 등 처리
+        this.actionBar.text = message;
     }
+
+#endregion
 }

--- a/Assets/Scripts/PhotonLauncher.cs
+++ b/Assets/Scripts/PhotonLauncher.cs
@@ -46,8 +46,6 @@ public class PhotonLauncher : MonoBehaviourPunCallbacks
 
         // AutomaticallySyncScene 옵션 때문에 모든 플레이어가 동일한 씬을 가지게 되므로
         if (PhotonNetwork.CurrentRoom.PlayerCount == 1)
-        {
             PhotonNetwork.LoadLevel("Game");
-        }
     }
 }


### PR DESCRIPTION
이 PR은 한 번에 많은 것을 만드는 것보다 최소한의 게임 로직을 구현하는 것을 목표로 설정합니다.

GameManager (세션)에 너무 많은 것을 위임하기엔 좋지 않을 것이라 생각하여 Phase 개념을 도입합니다.
구현 예정인 Phase는 아래와 같습니다.
- WaitPhase
  - 게임 인원 조건에 만족할 때까지 다른 플레이어를 대기합니다.
  - 게임 중 상태는 아니므로 모든 상호작용이 불가능해야 합니다.
- GamePhase
  - 실제 게임 상태로 술래 선정 및 대기, 아이템 스폰 등의 로직을 구현해야 합니다.
  - 충돌 판정은 여기에서 이루어지지는 않을 것입니다. _(이게 좋은 구조인지는 잘 모르겠네요)_

현재 Phase는 GameManager에서 접근할 수 있으며, `GameManager#ChangePhase(Phase)` 메서드로 페이즈를 전환할 수 있습니다.
